### PR TITLE
"Fix" off by one dates

### DIFF
--- a/src/components/MeetingEntry.vue
+++ b/src/components/MeetingEntry.vue
@@ -20,7 +20,7 @@ const props = defineProps({
       <h3>{{ title }}</h3>
       <div class="when-and-where">
         <span class="date">
-          {{ Intl.DateTimeFormat('default', {dateStyle: 'long'}).format(new Date(date)) }}
+          {{ Intl.DateTimeFormat('default', {dateStyle: 'long'}).format(new Date(`${date}T00:00:00`)) }}
         </span>
         <span v-if="location" class="location">
           at {{ location }}


### PR DESCRIPTION
Because `new Date` includes timezone, if you happen theoretically to live in a negative timezone offset location, then it will be the previous day. Fix this by fully specifying the time.