### PR TITLE
Fix 'base should start with /' warning.

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: 'game-club',
+  base: '/game-club',
   plugins: [vue()],
   resolve: {
     alias: {


### PR DESCRIPTION
Vite update must have introduced this warning sometime recently.